### PR TITLE
Fix lsblk --json error in Turkish language

### DIFF
--- a/etc/kernel/postinst.d/zz-update-systemd-boot
+++ b/etc/kernel/postinst.d/zz-update-systemd-boot
@@ -99,7 +99,7 @@ UUID = UUID.split("\n")[0]
 PARTS = json.loads(subprocess.check_output(["lsblk", "--output",
                                             "TYPE,SIZE,NAME,MOUNTPOINT",
                                             "--json",
-                                            "--bytes"]).decode())["blockdevices"]
+                                            "--bytes"]).decode().replace("I","i"))["blockdevices"]
 
 for each in range(len(PARTS) - 1, -1, -1):
     if ((PARTS[each]["type"] != "disk") or ("children" not in PARTS[each])):


### PR DESCRIPTION
## Problem
Running `lsblk --json --output NAME,SIZE` should normally give `{(...):{"name":"something","size":123}}`, however, when the language is set to Turkish, instead of filling in the field `size`, it instead fills `sIze`.

## Solution
This hotfix just replaces all "I" with "i" before loading the json.